### PR TITLE
feat: add API key security

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 APP_NAME="Laravel"
 APP_ENV=local
 APP_KEY=e4b210a2da6becfb822b8ec615a689df
+API_ACCESS_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# G-Saques API
+
+## API Security
+
+All API requests require an `X-API-Key` header. The value must match the `API_ACCESS_KEY` configured in your environment.
+
+Example request:
+
+```bash
+curl -H "X-API-Key: <your-key>" http://localhost/api/health
+```

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -18,13 +18,14 @@ class Kernel extends HttpKernel
      */
     protected $middlewareGroups = [
         'web' => [],
-        'api' => [],
+        'api' => ['ensure-api-key', 'throttle:60,1'],
     ];
 
     /**
      * The application's route middleware aliases.
      */
     protected $middlewareAliases = [
-        //
+        'ensure-api-key' => \App\Http\Middleware\EnsureApiKeyIsValid::class,
+        'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
     ];
 }

--- a/app/Http/Middleware/EnsureApiKeyIsValid.php
+++ b/app/Http/Middleware/EnsureApiKeyIsValid.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureApiKeyIsValid
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $expected = (string) config('app.api_key');
+        $provided = (string) $request->header('X-API-Key');
+
+        if ($expected === '' || !hash_equals($expected, $provided)) {
+            return response()->json(['message' => 'Unauthorized'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        return $next($request);
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -101,6 +101,8 @@ return [
 
     'key' => env('APP_KEY'),
 
+    'api_key' => env('API_ACCESS_KEY'),
+
     'previous_keys' => [
         ...array_filter(
             explode(',', env('APP_PREVIOUS_KEYS', ''))

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,3 +2,5 @@
 
 use Illuminate\Support\Facades\Route;
 
+Route::get('/health', fn () => response()->json(['status' => 'ok']));
+

--- a/tests/Feature/ApiKeyMiddlewareTest.php
+++ b/tests/Feature/ApiKeyMiddlewareTest.php
@@ -1,0 +1,19 @@
+<?php
+
+beforeEach(function () {
+    config(['app.api_key' => 'test-key']);
+});
+
+it('denies access without API key', function () {
+    $this->getJson('/api/health')->assertStatus(401);
+});
+
+it('denies access with invalid API key', function () {
+    $this->getJson('/api/health', ['X-API-Key' => 'invalid'])->assertStatus(401);
+});
+
+it('allows access with valid API key', function () {
+    $this->getJson('/api/health', ['X-API-Key' => 'test-key'])
+        ->assertOk()
+        ->assertJson(['status' => 'ok']);
+});


### PR DESCRIPTION
## Summary
- enforce X-API-Key authentication for all API routes
- configure API key via environment and document usage
- cover API key flow with feature tests

## Testing
- `composer install` *(fails: unable to access GitHub repository)*
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6893b471131c83258e77991a0907fd0e