### PR TITLE
fix: apply API middleware

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -3,5 +3,7 @@
 use App\Http\Controllers\TesteController;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/health', fn () => response()->json(['status' => 'ok']));
-Route::get('/teste', [TesteController::class, 'teste']);
+Route::middleware('api')->group(function () {
+    Route::get('/health', fn () => response()->json(['status' => 'ok']));
+    Route::get('/teste', [TesteController::class, 'teste']);
+});


### PR DESCRIPTION
## Summary
- wrap API routes in API middleware group so they require the API key

## Testing
- `php artisan test` *(fails: require vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_b_6894999b95308325871b81a065e841ab