### PR TITLE
Add unit tests for services and repositories

### DIFF
--- a/src/tests/Unit/BaseRepositoryTest.php
+++ b/src/tests/Unit/BaseRepositoryTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Models\Transfer;
+use Domain\Shared\Repositories\BaseRepository;
+use Mockery;
+use Tests\TestCase;
+
+class StubRepository extends BaseRepository
+{
+    protected string $modelClass = Transfer::class;
+}
+
+uses(TestCase::class);
+
+afterEach(function () {
+    Mockery::close();
+});
+
+it('delegates findById to findOne', function () {
+    $repo = Mockery::mock(StubRepository::class)->makePartial();
+    $repo->shouldReceive('findOne')->with(['id' => 5])->andReturn(['id' => 5]);
+
+    $result = $repo->findById(5);
+    expect($result)->toBe(['id' => 5]);
+});

--- a/src/tests/Unit/TransferRepositoryTest.php
+++ b/src/tests/Unit/TransferRepositoryTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Models\Transfer;
+use Domain\Shared\Repositories\BaseRepository;
+use Domain\Transfers\Repositories\TransferRepository;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+it('initializes with Transfer model', function () {
+    $repository = new TransferRepository();
+    expect($repository)->toBeInstanceOf(BaseRepository::class);
+
+    $reflection = new ReflectionClass($repository);
+    $property = $reflection->getProperty('modelClass');
+    $property->setAccessible(true);
+
+    expect($property->getValue($repository))->toBe('\\' . Transfer::class);
+});

--- a/src/tests/Unit/TransferServiceTest.php
+++ b/src/tests/Unit/TransferServiceTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Domain\Transfers\Contracts\TransferRepositoryContract;
+use Domain\Transfers\Services\TransferService;
+use Mockery;
+
+// Ensure Mockery expectations are verified and mocks are cleaned up
+afterEach(function () {
+    Mockery::close();
+});
+
+it('returns null when transfer to update does not exist', function () {
+    $repository = Mockery::mock(TransferRepositoryContract::class);
+    $repository->shouldReceive('findById')->with(1)->andReturn(null);
+    $repository->shouldNotReceive('update');
+
+    $service = new TransferService($repository);
+
+    $result = $service->updateTransfer(1, ['amount' => 100]);
+
+    expect($result)->toBeNull();
+});
+
+it('updates and returns transfer when record exists', function () {
+    $repository = Mockery::mock(TransferRepositoryContract::class);
+    $repository->shouldReceive('findById')->with(1)->andReturn([
+        'id' => 1,
+        'transfer_id' => 123,
+        'amount' => 100,
+    ]);
+    $repository->shouldReceive('update')->with(1, ['amount' => 200])->andReturn([
+        'id' => 1,
+        'transfer_id' => 123,
+        'amount' => 200,
+    ]);
+
+    $service = new TransferService($repository);
+
+    $result = $service->updateTransfer(1, ['amount' => 200]);
+
+    expect($result)->toBe([
+        'id' => 1,
+        'transfer_id' => 123,
+        'amount' => 200,
+    ]);
+});
+
+it('retrieves a transfer by transfer id', function () {
+    $repository = Mockery::mock(TransferRepositoryContract::class);
+    $repository->shouldReceive('findOne')->with(['transfer_id' => 123])->andReturn([
+        'id' => 1,
+        'transfer_id' => 123,
+        'amount' => 500,
+    ]);
+
+    $service = new TransferService($repository);
+
+    $result = $service->getTransfer(123);
+
+    expect($result)->toBe([
+        'id' => 1,
+        'transfer_id' => 123,
+        'amount' => 500,
+    ]);
+});
+

--- a/src/tests/Unit/WebhookRepositoryTest.php
+++ b/src/tests/Unit/WebhookRepositoryTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Models\Webhook;
+use Domain\Shared\Repositories\BaseRepository;
+use Domain\Webhooks\Repositories\WebhookRepository;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+it('initializes with Webhook model', function () {
+    $repository = new WebhookRepository();
+    expect($repository)->toBeInstanceOf(BaseRepository::class);
+
+    $reflection = new ReflectionClass($repository);
+    $property = $reflection->getProperty('modelClass');
+    $property->setAccessible(true);
+
+    expect($property->getValue($repository))->toBe('\\' . Webhook::class);
+});

--- a/src/tests/Unit/WebhookServiceTest.php
+++ b/src/tests/Unit/WebhookServiceTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Domain\Webhooks\Repositories\WebhookRepository;
+use Domain\Webhooks\Services\WebhookService;
+use Illuminate\Support\Facades\Http;
+use Mockery;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+afterEach(function () {
+    Mockery::close();
+});
+
+it('sends webhook and updates repository', function () {
+    Http::fake([
+        'http://example.com/*' => Http::response(['result' => 'ok'], 200),
+    ]);
+
+    $webhook = [
+        'id' => 1,
+        'url' => 'http://example.com/hook',
+        'raw' => json_encode(['foo' => 'bar']),
+        'attempts' => 3,
+    ];
+
+    $repository = Mockery::mock(WebhookRepository::class);
+    $repository->shouldReceive('findById')->with(1)->andReturn($webhook);
+    $repository->shouldReceive('update')->with(1, Mockery::on(function ($data) {
+        return $data['status'] === 'sent' && $data['response_status'] === 200;
+    }))->andReturn(array_merge($webhook, ['status' => 'sent', 'response_status' => 200]));
+
+    $service = new WebhookService($repository);
+    $service->send(['id' => 1], true);
+});


### PR DESCRIPTION
## Summary
- add Pest unit tests for shared BaseRepository and domain repositories
- cover WebhookService send behavior

## Testing
- `composer install --no-interaction --no-progress --prefer-dist --no-scripts` *(failed: CONNECT tunnel failed while cloning dependencies)*
- `./vendor/bin/pest` *(failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68a306cc8b70832587fb8861a8e9aa8c