### PR TITLE
test: replace mockery with phpunit mocks

### DIFF
--- a/src/tests/Unit/BaseRepositoryTest.php
+++ b/src/tests/Unit/BaseRepositoryTest.php
@@ -2,7 +2,6 @@
 
 use App\Models\Transfer;
 use Domain\Shared\Repositories\BaseRepository;
-use Mockery;
 use Tests\TestCase;
 
 class StubRepository extends BaseRepository
@@ -12,13 +11,15 @@ class StubRepository extends BaseRepository
 
 uses(TestCase::class);
 
-afterEach(function () {
-    Mockery::close();
-});
-
 it('delegates findById to findOne', function () {
-    $repo = Mockery::mock(StubRepository::class)->makePartial();
-    $repo->shouldReceive('findOne')->with(['id' => 5])->andReturn(['id' => 5]);
+    $repo = $this->getMockBuilder(StubRepository::class)
+        ->onlyMethods(['findOne'])
+        ->getMock();
+
+    $repo->expects($this->once())
+        ->method('findOne')
+        ->with(['id' => 5])
+        ->willReturn(['id' => 5]);
 
     $result = $repo->findById(5);
     expect($result)->toBe(['id' => 5]);

--- a/src/tests/Unit/TransferServiceTest.php
+++ b/src/tests/Unit/TransferServiceTest.php
@@ -2,17 +2,14 @@
 
 use Domain\Transfers\Contracts\TransferRepositoryContract;
 use Domain\Transfers\Services\TransferService;
-use Mockery;
-
-// Ensure Mockery expectations are verified and mocks are cleaned up
-afterEach(function () {
-    Mockery::close();
-});
 
 it('returns null when transfer to update does not exist', function () {
-    $repository = Mockery::mock(TransferRepositoryContract::class);
-    $repository->shouldReceive('findById')->with(1)->andReturn(null);
-    $repository->shouldNotReceive('update');
+    $repository = $this->createMock(TransferRepositoryContract::class);
+    $repository->expects($this->once())
+        ->method('findById')
+        ->with(1)
+        ->willReturn(null);
+    $repository->expects($this->never())->method('update');
 
     $service = new TransferService($repository);
 
@@ -22,45 +19,52 @@ it('returns null when transfer to update does not exist', function () {
 });
 
 it('updates and returns transfer when record exists', function () {
-    $repository = Mockery::mock(TransferRepositoryContract::class);
-    $repository->shouldReceive('findById')->with(1)->andReturn([
+    $repository = $this->createMock(TransferRepositoryContract::class);
+    $existing = [
         'id' => 1,
         'transfer_id' => 123,
         'amount' => 100,
-    ]);
-    $repository->shouldReceive('update')->with(1, ['amount' => 200])->andReturn([
+    ];
+    $updated = [
         'id' => 1,
         'transfer_id' => 123,
         'amount' => 200,
-    ]);
+    ];
+
+    $repository->expects($this->once())
+        ->method('findById')
+        ->with(1)
+        ->willReturn($existing);
+
+    $repository->expects($this->once())
+        ->method('update')
+        ->with(1, ['amount' => 200])
+        ->willReturn($updated);
 
     $service = new TransferService($repository);
 
     $result = $service->updateTransfer(1, ['amount' => 200]);
 
-    expect($result)->toBe([
-        'id' => 1,
-        'transfer_id' => 123,
-        'amount' => 200,
-    ]);
+    expect($result)->toBe($updated);
 });
 
 it('retrieves a transfer by transfer id', function () {
-    $repository = Mockery::mock(TransferRepositoryContract::class);
-    $repository->shouldReceive('findOne')->with(['transfer_id' => 123])->andReturn([
+    $repository = $this->createMock(TransferRepositoryContract::class);
+    $transfer = [
         'id' => 1,
         'transfer_id' => 123,
         'amount' => 500,
-    ]);
+    ];
+
+    $repository->expects($this->once())
+        ->method('findOne')
+        ->with(['transfer_id' => 123])
+        ->willReturn($transfer);
 
     $service = new TransferService($repository);
 
     $result = $service->getTransfer(123);
 
-    expect($result)->toBe([
-        'id' => 1,
-        'transfer_id' => 123,
-        'amount' => 500,
-    ]);
+    expect($result)->toBe($transfer);
 });
 

--- a/src/tests/Unit/WebhookServiceTest.php
+++ b/src/tests/Unit/WebhookServiceTest.php
@@ -3,14 +3,9 @@
 use Domain\Webhooks\Repositories\WebhookRepository;
 use Domain\Webhooks\Services\WebhookService;
 use Illuminate\Support\Facades\Http;
-use Mockery;
 use Tests\TestCase;
 
 uses(TestCase::class);
-
-afterEach(function () {
-    Mockery::close();
-});
 
 it('sends webhook and updates repository', function () {
     Http::fake([
@@ -24,11 +19,17 @@ it('sends webhook and updates repository', function () {
         'attempts' => 3,
     ];
 
-    $repository = Mockery::mock(WebhookRepository::class);
-    $repository->shouldReceive('findById')->with(1)->andReturn($webhook);
-    $repository->shouldReceive('update')->with(1, Mockery::on(function ($data) {
-        return $data['status'] === 'sent' && $data['response_status'] === 200;
-    }))->andReturn(array_merge($webhook, ['status' => 'sent', 'response_status' => 200]));
+    $repository = $this->createMock(WebhookRepository::class);
+    $repository->expects($this->once())
+        ->method('findById')
+        ->with(1)
+        ->willReturn($webhook);
+    $repository->expects($this->once())
+        ->method('update')
+        ->with(1, $this->callback(function ($data) {
+            return $data['status'] === 'sent' && $data['response_status'] === 200;
+        }))
+        ->willReturn(array_merge($webhook, ['status' => 'sent', 'response_status' => 200]));
 
     $service = new WebhookService($repository);
     $service->send(['id' => 1], true);


### PR DESCRIPTION
## Summary
- replace Mockery usage with PHPUnit mocks in unit tests

## Testing
- `php vendor/bin/pest` *(fails: Could not open input file: vendor/bin/pest)*

------
https://chatgpt.com/codex/tasks/task_b_68a30d17c86c83259437201ab0bf9be0